### PR TITLE
Logfixes simpler

### DIFF
--- a/NwalaTextUtils/textutils.py
+++ b/NwalaTextUtils/textutils.py
@@ -10,8 +10,6 @@ from multiprocessing import Pool
 
 logger = logging.getLogger('NwalaTextUtils.textutils')
 
-logger.critical("stuff was done here...")
-
 def genericErrorInfo():
 	exc_type, exc_obj, exc_tb = sys.exc_info()
 	fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]

--- a/NwalaTextUtils/textutils.py
+++ b/NwalaTextUtils/textutils.py
@@ -9,42 +9,8 @@ from bs4 import BeautifulSoup
 from multiprocessing import Pool
 
 logger = logging.getLogger('NwalaTextUtils.textutils')
-fileHandler = None
-consoleHandler = logging.StreamHandler()
 
-def setLoggerDets(loggerDets):
-
-	if( len(loggerDets) == 0 ):
-		return
-
-	if( 'level' in loggerDets ):
-		logger.setLevel( loggerDets['level'] )
-	else:
-		logger.setLevel( logging.ERROR )
-
-	if( 'file' in loggerDets ):
-		if( loggerDets['file'] != '' ):
-			fileHandler = logging.FileHandler( loggerDets['file'] )
-			procLogHandler(fileHandler, loggerDets)
-
-	procLogHandler(consoleHandler, loggerDets)
-	
-def procLogHandler(handler, loggerDets):
-	
-	if( handler is None ):
-		return
-
-	formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-	handler.setFormatter(formatter)
-		
-	if( 'level' in loggerDets ):
-		handler.setLevel( loggerDets['level'] )	
-
-	if( 'format' in loggerDets ):
-		formatter = logging.Formatter( loggerDets['format'] )
-		handler.setFormatter(formatter)
-
-	logger.addHandler(handler)
+logger.critical("stuff was done here...")
 
 def genericErrorInfo():
 	exc_type, exc_obj, exc_tb = sys.exc_info()
@@ -98,69 +64,57 @@ def downloadSave(response, outfile):
 	except:
 		logger.error( genericErrorInfo() )
 
-def mimicBrowser(uri, getRequestFlag=True, params=None):
+def mimicBrowser(uri, getRequestFlag=True, timeout=10, sizeRestrict=-1, addResponseHeader=False, saveFilePath=None, headers={}):
 	
 	uri = uri.strip()
 	if( len(uri) == 0 ):
 		return ''
 
-	if( params is None ):
-		params = {}
-
-	params.setdefault('timeout', 10)
-	params.setdefault('sizeRestrict', -1)
-	params.setdefault('headers', getCustomHeaderDict())
-	params.setdefault('addResponseHeader', False)
-
+	if headers == {}:
+		headers = getCustomHeaderDict()
 
 	try:
 		response = ''
 		reponseText = ''
-		if( getRequestFlag ):
+		if( getRequestFlag is True ):
 
-			if( 'saveFilePath' in params ):
-				response = requests.get(uri, headers=params['headers'], timeout=params['timeout'], stream=True)#, verify=False
+			if( saveFilePath is not None ):
+				response = requests.get(uri, headers=headers, timeout=timeout, stream=True) #, verify=False
 			else:
-				response = requests.get(uri, headers=params['headers'], timeout=params['timeout'])#, verify=False
+				response = requests.get(uri, headers=headers, timeout=timeout) #, verify=False
 			
-			if( params['sizeRestrict'] != -1 ):
-				if( isSizeLimitExceed(response.headers, params['sizeRestrict']) ):
-					return 'Error: Exceeded size restriction: ' + str(params['sizeRestrict'])
+			if( sizeRestrict != -1 ):
+				if( isSizeLimitExceed(response.headers, sizeRestrict) ):
+					return 'Error: Exceeded size restriction: ' + sizeRestrict
 
 			
-			if( 'saveFilePath' in params ):
-				downloadSave(response, params['saveFilePath'])
+			if( saveFilePath is not None ):
+				downloadSave(response, saveFilePath)
 			else:
 				reponseText = response.text
 
-			if( params['addResponseHeader'] ):
+			if( addResponseHeader is True ):
 				return	{'responseHeader': response.headers, 'text': reponseText}
 
 			return reponseText
 		else:
-			response = requests.head(uri, headers=params['headers'], timeout=params['timeout'])#, verify=False
+			response = requests.head(uri, headers=headers, timeout=timeout)#, verify=False
 			response.headers['status-code'] = response.status_code
 			return response.headers
 	except:
 		logger.error(genericErrorInfo() + ', uri:' + uri)
 
-		if( getRequestFlag == False ):
+		if( getRequestFlag is False ):
 			return {}
 	
 	return ''
 
-def derefURI(uri, sleepSec=0, params=None):
+def derefURI(uri, sleepSec=0, sizeRestrict=4000000, headers={}, timeout=10):
 	
 	uri = uri.strip()
 	if( len(uri) == 0 ):
 		return ''
 
-	if( params is None ):
-		params = {}
-
-	params.setdefault('loggerDets', {})
-	setLoggerDets( params['loggerDets'] )
-	
 	htmlPage = ''
 	try:
 		
@@ -168,8 +122,7 @@ def derefURI(uri, sleepSec=0, params=None):
 			logger.info( 'derefURI(), sleep:' + str(sleepSec) )
 			time.sleep(sleepSec)
 
-		params.setdefault('sizeRestrict', 4000000)
-		htmlPage = mimicBrowser(uri, params=params)
+		htmlPage = mimicBrowser(uri, sizeRestrict=sizeRestrict, headers=headers, timeout=timeout)
 	except:
 		err = genericErrorInfo()
 		logger.error( err )
@@ -234,19 +187,11 @@ def cleanHtml(html, method='python-boilerpipe'):
 
 	return ''
 
-def prlGetTxtFrmURIs(urisLst, params=None):
+def prlGetTxtFrmURIs(urisLst, updateRate=10):
 
 	size = len(urisLst)
 	if( size == 0 ):
 		return []
-
-	if( params is None ):
-		params = {}
-
-	params.setdefault('loggerDets', {})
-	setLoggerDets( params['loggerDets'] )
-
-	params['loggerDets'].setdefault('updateRate', 10)
 
 	docsLst = []
 	jobsLst = []
@@ -254,8 +199,8 @@ def prlGetTxtFrmURIs(urisLst, params=None):
 
 		printMsg = ''
 
-		if( i % params['loggerDets']['updateRate'] == 0 ):
-			printMsg = 'dereferencing uri i: ' + str(i) + ' of ' + str(size)
+		if( i % updateRate == 0 ):
+			printMsg = 'dereferencing uri ' + str(i) + ' of ' + str(size)
 
 		keywords = {
 			'uri': urisLst[i],

--- a/README.md
+++ b/README.md
@@ -27,35 +27,17 @@ $ pip install NwalaTextUtils
 
 ## Function Documentation and Usage Examples
 
-### Dereference URI with `derefURI(uri, sleepSec=0, params=None)`: 
+### Dereference URI with `derefURI(uri, sleepSec=0, sizeRestrict=4000000, headers={}, timeout=10)`: 
 Returns HTML text from `uri`. Set `sleepSec` (sleep seconds) > 0 to throttle (sleep) request.
-Dictionary `params` options:
 
-* (bool) `addResponseHeader`: Default = False. False - returns only HTML text payload. True - returns dict containing HTML text and Server response headers.
+* (int) `sleepSec`: Default = 0. The number of seconds to sleep before the request.
 
-* (dict) `headers`: Default = [getCustomHeaderDict()](https://github.com/oduwsdl/NwalaTextUtils/blob/logfixes/NwalaTextUtils/textutils.py#L69). User-supplied HTTP Request headers.
-
-* (dict) `loggerDets`: Default = {}. Specifies log options. To switch on console logs, set `params['loggerDets']` as follows
-	```
-	params = {
-		'loggerDets':{		
-			'level': logging.INFO,
-		}
-	}
-	```
-
-	To write log to file, set `params['loggerDets']['file']`, e.g.,
-	```
-	params['loggerDets']['file'] = '/path/to/logs.log'
-	```
-
-	To use custom log format set `params['loggerDets']['format']`, e.g.,
-	```
-	params['loggerDets']['format'] = '%(asctime)s * %(name)s * %(levelname)s * %(message)s'
-	```
 * (int)  `sizeRestrict`: Default = 4,000,000 (~4 MB). Maximum size of HTML payload. If Content-Length exceeds this size, content would be discarded.
 
 * (int)  `timeout`: Default = 10, Argument passed to [timeout to requests.get](https://2.python-requests.org/en/master/user/quickstart/#timeouts)
+
+* (dict) `headers`: Default = {}. If default is specified, then [getCustomHeaderDict()](https://github.com/oduwsdl/NwalaTextUtils/blob/logfixes/NwalaTextUtils/textutils.py#L69) is called to fill this value with sensible defaults. User-supplied HTTP Request headers.
+
 
 ### Remove boilerplate from HTML with `cleanHtml(html, method='python-boilerpipe')`:
 Returns plaintext after removing HTML boilerplate from `html` using either the default [recommended](https://ws-dl.blogspot.com/2017/03/2017-03-20-survey-of-5-boilerplate.html) boilerplate removal method, `python-boilerpipe` or [NLTK's regex method](https://github.com/nltk/nltk/commit/39a303e5ddc4cdb1a0b00a3be426239b1c24c8bb).
@@ -80,17 +62,15 @@ print('html prefix:\n', html[:100].strip(), '\n')
 print('plaintext prefix:\n', plaintext[:100].strip(), '\n')
 ```
 
-### Dereference and Remove Boilerplate from URIs with `prlGetTxtFrmURIs(urisLst, params=None)`:
-Dereference and remove boilerplate from URIs (within `urisLst`) in parallel. `params` activates more functionalities such a activating and controlling the console logging details (see [`loggerDets`](#dereference-uri-with-derefuriuri-sleepsec0-paramsnone) above). You might need status updates (instead of the default silence) when dereferencing a large list of URIs. To control how often the log is printed, set `params['loggerDets']['updateRate']`, e.g.,
+### Dereference and Remove Boilerplate from URIs with `prlGetTxtFrmURIs(urisLst, updateRate=10)`:
 
-```
-params['loggerDets']['updateRate'] = 10 #print 1 message per 10 log status updates
-```
+* (list) `urisLst`: The list of URIs to dereference and remove boilerplate from.
+
+* (int) `updateRate`: Default = 10. Print 1 message per `updateRate` log status updates.
 
 Usage example:
 ```
 import json
-import logging
 from NwalaTextUtils.textutils import prlGetTxtFrmURIs
 
 uris_lst = [
@@ -99,15 +79,8 @@ uris_lst = [
     'https://www.scientificamerican.com/article/why-ebola-survivors-struggle-with-new-symptoms/'
   ]
 
-params = {}
-'''
-#To print console logs, set params accordingly:
-params = { 
-	'loggerDets': {'level': logging.INFO} 
-}
-'''
 
-doc_lst = prlGetTxtFrmURIs(uris_lst, params=params)
+doc_lst = prlGetTxtFrmURIs(uris_lst)
 with open('doc_lst.json', 'w') as outfile:
     json.dump(doc_lst, outfile)
 ```


### PR DESCRIPTION
Here I have provided some changes to logfixes that will make it easier for others to consume this module.

Notes:
* params={'a': 'b', ...} has been replaced by explicitly named parameters for these functions
* logging has been simplified - it is up to the calling function/module/script to specify the logging level, handlers, etc. - don't try to do their work for them - if such functions are needed, put them in another file in this module (like I did for the OTMT)
* I tried to update the README as appropriate